### PR TITLE
Add the verified role to registered users

### DIFF
--- a/convex/actions/discord.ts
+++ b/convex/actions/discord.ts
@@ -119,3 +119,41 @@ export const applyTags = internalAction({
     await thread.setAppliedTags(tags);
   },
 });
+
+export const addRole = internalAction({
+  args: {
+    discordUserId: v.string(),
+    guildId: v.string(),
+    roleId: v.string(),
+  },
+  handler: async (_ctx, { discordUserId, guildId, roleId }) => {
+    const bot = await discordClient();
+
+    const guild = await bot.guilds.fetch(guildId);
+    if (!guild) throw new Error(`Can’t find guild ${guildId}`);
+
+    const member = await guild.members.fetch(discordUserId);
+    if (member) {
+      await member.roles.add(roleId);
+    }
+  },
+});
+
+export const removeRole = internalAction({
+  args: {
+    discordUserId: v.string(),
+    guildId: v.string(),
+    roleId: v.string(),
+  },
+  handler: async (_ctx, { discordUserId, guildId, roleId }) => {
+    const bot = await discordClient();
+
+    const guild = await bot.guilds.fetch(guildId);
+    if (!guild) throw new Error(`Can’t find guild ${guildId}`);
+
+    const member = await guild.members.fetch(discordUserId);
+    if (member) {
+      await member.roles.remove(roleId);
+    }
+  },
+});

--- a/convex/actions/discord.ts
+++ b/convex/actions/discord.ts
@@ -132,9 +132,11 @@ export const addRole = internalAction({
     const guild = await bot.guilds.fetch(guildId);
     if (!guild) throw new Error(`Can’t find guild ${guildId}`);
 
-    const member = await guild.members.fetch(discordUserId);
-    if (member) {
+    try {
+      const member = await guild.members.fetch(discordUserId);
       await member.roles.add(roleId);
+    } catch {
+      // Ignore
     }
   },
 });
@@ -151,9 +153,11 @@ export const removeRole = internalAction({
     const guild = await bot.guilds.fetch(guildId);
     if (!guild) throw new Error(`Can’t find guild ${guildId}`);
 
-    const member = await guild.members.fetch(discordUserId);
-    if (member) {
+    try {
+      const member = await guild.members.fetch(discordUserId);
       await member.roles.remove(roleId);
+    } catch {
+      // Ignore
     }
   },
 });

--- a/convex/discord.ts
+++ b/convex/discord.ts
@@ -408,7 +408,7 @@ export const isAccountLinked = internalQuery({
       .query("registrations")
       .withIndex("discordUserId", (q) => q.eq("discordUserId", discordUserId))
       .first();
-    return discordUserId !== null;
+    return registration !== null;
   },
 });
 
@@ -428,7 +428,7 @@ export const addRoleIfAccountLinked = action({
     });
 
     if (isAccountLinked) {
-      runAction(internal.actions.discord.addRole, {
+      await runAction(internal.actions.discord.addRole, {
         guildId,
         discordUserId,
         roleId,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,9 +1,10 @@
 import { httpRouter } from "convex/server";
 import { interactivityHandler, slashHandler } from "./slack";
+import { registerAccountHandler, unregisterAccountHandler } from "./discord";
 
 const http = httpRouter();
 
-// Define additional routes
+// Slack webhooks
 http.route({
   path: "/slack/slash",
   method: "POST",
@@ -13,6 +14,18 @@ http.route({
   path: "/slack/interactivity",
   method: "POST",
   handler: interactivityHandler,
+});
+
+// Custom webhooks to manage verified user status
+http.route({
+  path: "/discord/registerAccount",
+  method: "POST",
+  handler: registerAccountHandler,
+});
+http.route({
+  path: "/discord/unregisterAccount",
+  method: "POST",
+  handler: unregisterAccountHandler,
 });
 
 // Convex expects the router to be the default export of `convex/http.js`.

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -154,6 +154,11 @@ export const Users = Table("users", {
   userId: deprecated,
 });
 
+export const Registrations = Table("registrations", {
+  discordUserId: v.string(),
+  associatedAccountId: v.string(),
+});
+
 export default defineSchema({
   channels: Channels.table.index("id", ["id"]),
   messages: Messages.table
@@ -165,6 +170,7 @@ export default defineSchema({
     .index("slackThreadTs", ["slackThreadTs"])
     .index("version", ["version"]),
   users: Users.table.index("id", ["id"]),
+  registrations: Registrations.table.index("discordUserId", ["discordUserId"]),
   threadSearchStatus: defineTable({
     indexedCursor: v.number(),
   }),

--- a/discordBot.ts
+++ b/discordBot.ts
@@ -102,6 +102,16 @@ bot.on("interactionCreate", async (interaction) => {
   }
 });
 
+bot.on("guildMemberAdd", async (member) => {
+  try {
+    await convex.action(api.discord.addRoleIfAccountLinked, {
+      discordUserId: member.id,
+    });
+  } catch (e) {
+    console.error(e);
+  }
+});
+
 const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 if (!DISCORD_TOKEN) throw "Need DISCORD_TOKEN env variable";
 


### PR DESCRIPTION
This PR makes the Discord bot add and remove a role to verified users. This works both if the user is already on the Discord server and if they join later.

It also displays the associated user ID in the forwarded messages on Slack:

![](https://github.com/ianmacartney/discord-slack-bridge/assets/7029582/110d9bcb-b745-4963-9edd-47b7f9e24bee)

To register and unregister users, two new HTTP endpoints are added (`/discord/registerAccount` and `/discord/unregisterAccount`). The state is stored in the Convex database so that it can be used later.

The following environment variables need to be added to the Convex deployment:

* `DISCORD_VERIFIED_ROLE_ID`
* `DISCORD_GUILD_ID`
* `WEBHOOK_TOKEN` (can be anything, it just needs to be consistent with what is used in the HTTP calls; this works as a security measure to prevent calls from unauthorized users).