### PR TITLE
Auto-reply to new support threads

### DIFF
--- a/packages/db/convex/discord.ts
+++ b/packages/db/convex/discord.ts
@@ -140,7 +140,26 @@ export const receiveMessage = apiMutation({
       threadId,
     });
 
-    //TODO: handle message type USER_JOIN
+    // If it's a new thread (where the message and thread IDs match) in the
+    // #support-community channel, send an auto-reply.
+    if (
+      dbThread &&
+      message.id === dbThread.id &&
+      channel.name === "support-community"
+    ) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.discord_node.replyToSupportThread,
+        {
+          threadId: dbThread.id,
+        },
+      );
+    }
+
+    // If the message is in a channel with an associated Slack channel, forward
+    // it to that Slack channel.
+    //
+    // TODO: handle message type USER_JOIN
     if (
       // 0: DEFAULT 19: REPLY
       (message.type === 0 || message.type === 19) &&

--- a/packages/db/convex/discord.ts
+++ b/packages/db/convex/discord.ts
@@ -145,7 +145,7 @@ export const receiveMessage = apiMutation({
     if (
       dbThread &&
       message.id === dbThread.id &&
-      channel.name === "support-community"
+      channel.id === process.env.AUTO_REPLY_CHANNEL_ID
     ) {
       await ctx.scheduler.runAfter(
         0,

--- a/packages/db/convex/discord_node.ts
+++ b/packages/db/convex/discord_node.ts
@@ -1,15 +1,20 @@
 "use node";
-import { internal } from "./_generated/api";
 import { v } from "convex/values";
+import {
+  ChannelType,
+  Client,
+  EmbedBuilder,
+  GatewayIntentBits,
+} from "discord.js";
 import {
   serializeAuthor,
   serializeChannel,
   serializeMessage,
   serializeThread,
 } from "../shared/discordUtils";
-import { internalAction } from "./_generated/server";
-import { ChannelType, Client, GatewayIntentBits } from "discord.js";
+import { internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
+import { internalAction } from "./_generated/server";
 import { DiscordMessage, DiscordUser } from "./schema";
 
 const discordClient = async () => {
@@ -97,6 +102,44 @@ export const replyFromSlack = internalAction({
     }
 
     await channel.send(`<@${userId}>: ${reply}`);
+  },
+});
+
+export const replyToSupportThread = internalAction({
+  args: {
+    threadId: v.string(),
+  },
+  handler: async (ctx, { threadId }) => {
+    const bot = await discordClient();
+
+    const thread = await bot.channels.fetch(threadId);
+    if (!thread) {
+      throw new Error(`Thread ${threadId} not found`);
+    }
+    if (
+      thread.type !== ChannelType.PublicThread &&
+      thread.type !== ChannelType.PrivateThread
+    ) {
+      throw new Error("Can only reply to threads");
+    }
+
+    const embed = new EmbedBuilder().setColor("#d7b3cf").setDescription(
+      `**Thanks for posting in <#1088161997662724167>.**
+Just a reminder: If you have a [Convex Pro account](https://www.convex.dev/pricing), please create a support ticket through your [Convex Dashboard](https://dashboard.convex.dev/) for any support requests.
+
+You can search for answers using [search.convex.dev](https://search.convex.dev), which covers docs, Stack, and Discord. Additionally, you can <@1072591948499664996> in the ⁠Convex Community <#1228095053885476985> channel.
+
+**Posting guidelines:**
+1. Provide context: What are you trying to achieve, what is the end-user interaction?
+1. Include full details of what you're seeing (full error message, command output, etc.)
+1. Describe what you'd like to see instead.
+
+Please note that community support is available here, and avoid tagging staff unless specifically instructed. Thank you!`,
+    );
+
+    await thread.send({
+      embeds: [embed],
+    });
   },
 });
 

--- a/packages/db/convex/discord_node.ts
+++ b/packages/db/convex/discord_node.ts
@@ -109,7 +109,7 @@ export const replyToSupportThread = internalAction({
   args: {
     threadId: v.string(),
   },
-  handler: async (ctx, { threadId }) => {
+  handler: async ({}, { threadId }) => {
     const bot = await discordClient();
 
     const thread = await bot.channels.fetch(threadId);
@@ -127,7 +127,7 @@ export const replyToSupportThread = internalAction({
       `**Thanks for posting in <#1088161997662724167>.**
 Just a reminder: If you have a [Convex Pro account](https://www.convex.dev/pricing), please create a support ticket through your [Convex Dashboard](https://dashboard.convex.dev/) for any support requests.
 
-You can search for answers using [search.convex.dev](https://search.convex.dev), which covers docs, Stack, and Discord. Additionally, you can <@1072591948499664996> in the ⁠Convex Community <#1228095053885476985> channel.
+You can search for answers using [search.convex.dev](https://search.convex.dev), which covers docs, Stack, and Discord. Additionally, you can post in the <#1228095053885476985> channel to get a response from <@1072591948499664996>.
 
 **Posting guidelines:**
 1. Provide context: What are you trying to achieve, what is the end-user interaction?

--- a/packages/db/convex/migrations.ts
+++ b/packages/db/convex/migrations.ts
@@ -1,16 +1,16 @@
 import {
   cancelMigration,
   getStatus,
-  // makeMigration,
+  makeMigration,
   startMigrationsSerially,
 } from "convex-helpers/server/migrations";
 import { internalMutation, internalQuery } from "./_generated/server";
-// import { internal } from "./_generated/api";
+import { internal } from "./_generated/api";
 import { v } from "convex/values";
 
-// const migration = makeMigration(internalMutation, {
-//   migrationTable: "migrations",
-// });
+const migration = makeMigration(internalMutation, {
+  migrationTable: "migrations",
+});
 
 // export const deleteDeprecatedUserFields = migration({
 //   table: "users",

--- a/packages/db/convex/migrations.ts
+++ b/packages/db/convex/migrations.ts
@@ -1,16 +1,16 @@
 import {
   cancelMigration,
   getStatus,
-  makeMigration,
+  // makeMigration,
   startMigrationsSerially,
 } from "convex-helpers/server/migrations";
 import { internalMutation, internalQuery } from "./_generated/server";
-import { internal } from "./_generated/api";
+// import { internal } from "./_generated/api";
 import { v } from "convex/values";
 
-const migration = makeMigration(internalMutation, {
-  migrationTable: "migrations",
-});
+// const migration = makeMigration(internalMutation, {
+//   migrationTable: "migrations",
+// });
 
 // export const deleteDeprecatedUserFields = migration({
 //   table: "users",

--- a/packages/db/discordBot.ts
+++ b/packages/db/discordBot.ts
@@ -1,5 +1,5 @@
 import { api } from "./convex/_generated/api.js";
-import { ChannelType, Client, GatewayIntentBits } from "discord.js";
+import { ChannelType, Client, EmbedBuilder, GatewayIntentBits } from "discord.js";
 import { ConvexHttpClient } from "convex/browser";
 import {
   serializeAuthor,
@@ -28,6 +28,39 @@ const bot = new Client({
 
 bot.on("ready", () => {
   console.log(`Logged in as ${bot.user?.tag}!`);
+  console.log(
+    `Bot is in ${bot.guilds.cache.size} guilds: ${bot.guilds.cache.map((guild) => guild.name).join(", ")}`,
+  );
+});
+
+bot.on("threadCreate", async (thread) => {
+  // Check if the thread is in the "support-community" channel.
+  if (thread.parent?.name !== "support-community") {
+    return;
+  }
+
+  try {
+    const embed = new EmbedBuilder()
+      .setColor("#d7b3cf")
+      .setTitle("Convex Support")
+      .setDescription(
+        `Thanks for building on Convex! Just a reminder: If you have a [Convex Pro account](https://www.convex.dev/pricing), please create a support ticket through your [Convex Dashboard](https://dashboard.convex.dev/) for any support requests.
+
+For users on the Convex Starter plan, you can search for answers using [search.convex.dev](https://search.convex.dev), which covers docs, Stack, and Discord. Additionally, you can chat with <@1072591948499664996> in the <#1228095053885476985> channel.
+
+Please note that community support is available here, and avoid tagging staff unless specifically instructed. Thank you!`,
+      );
+
+    await thread.send({
+      content: "Thank you for reaching out to Convex support!",
+      embeds: [embed],
+    });
+  } catch (error) {
+    console.error(
+      `Failed to send auto-reply to #support-community thread: ${thread.name}`,
+      error,
+    );
+  }
 });
 
 bot.on("messageCreate", async (msg) => {

--- a/packages/db/discordBot.ts
+++ b/packages/db/discordBot.ts
@@ -1,5 +1,10 @@
 import { api } from "./convex/_generated/api.js";
-import { ChannelType, Client, EmbedBuilder, GatewayIntentBits } from "discord.js";
+import {
+  ChannelType,
+  Client,
+  EmbedBuilder,
+  GatewayIntentBits,
+} from "discord.js";
 import { ConvexHttpClient } from "convex/browser";
 import {
   serializeAuthor,
@@ -40,19 +45,21 @@ bot.on("threadCreate", async (thread) => {
   }
 
   try {
-    const embed = new EmbedBuilder()
-      .setColor("#d7b3cf")
-      .setTitle("Convex Support")
-      .setDescription(
-        `Thanks for building on Convex! Just a reminder: If you have a [Convex Pro account](https://www.convex.dev/pricing), please create a support ticket through your [Convex Dashboard](https://dashboard.convex.dev/) for any support requests.
+    const embed = new EmbedBuilder().setColor("#d7b3cf").setDescription(
+      `**Thanks for posting in <#1088161997662724167>.**
+Just a reminder: If you have a [Convex Pro account](https://www.convex.dev/pricing), please create a support ticket through your [Convex Dashboard](https://dashboard.convex.dev/) for any support requests.
 
-For users on the Convex Starter plan, you can search for answers using [search.convex.dev](https://search.convex.dev), which covers docs, Stack, and Discord. Additionally, you can chat with <@1072591948499664996> in the <#1228095053885476985> channel.
+If you're on the Convex Starter plan, you can search for answers using [search.convex.dev](https://search.convex.dev), which covers docs, Stack, and Discord. Additionally, you can <@1072591948499664996> in the ⁠Convex Community <#1228095053885476985> channel.
+
+**Posting guidelines:**
+1. Provide context: What are you trying to achieve, what is the end-user interaction?
+1. Include full details of what you're seeing (full error message, command output, etc.)
+1. Describe what you'd like to see instead.
 
 Please note that community support is available here, and avoid tagging staff unless specifically instructed. Thank you!`,
-      );
+    );
 
     await thread.send({
-      content: "Thank you for reaching out to Convex support!",
       embeds: [embed],
     });
   } catch (error) {
@@ -87,7 +94,7 @@ bot.on("messageCreate", async (msg) => {
   console.log(
     `${args.author.username}: ${args.message.cleanContent} (${
       args.channel.id
-    }/${args.thread?.id ?? ""})`
+    }/${args.thread?.id ?? ""})`,
   );
   // Upload to Convex
   try {

--- a/packages/db/discordBot.ts
+++ b/packages/db/discordBot.ts
@@ -49,7 +49,7 @@ bot.on("threadCreate", async (thread) => {
       `**Thanks for posting in <#1088161997662724167>.**
 Just a reminder: If you have a [Convex Pro account](https://www.convex.dev/pricing), please create a support ticket through your [Convex Dashboard](https://dashboard.convex.dev/) for any support requests.
 
-If you're on the Convex Starter plan, you can search for answers using [search.convex.dev](https://search.convex.dev), which covers docs, Stack, and Discord. Additionally, you can <@1072591948499664996> in the ⁠Convex Community <#1228095053885476985> channel.
+You can search for answers using [search.convex.dev](https://search.convex.dev), which covers docs, Stack, and Discord. Additionally, you can <@1072591948499664996> in the ⁠Convex Community <#1228095053885476985> channel.
 
 **Posting guidelines:**
 1. Provide context: What are you trying to achieve, what is the end-user interaction?

--- a/packages/db/discordBot.ts
+++ b/packages/db/discordBot.ts
@@ -1,10 +1,5 @@
 import { api } from "./convex/_generated/api.js";
-import {
-  ChannelType,
-  Client,
-  EmbedBuilder,
-  GatewayIntentBits,
-} from "discord.js";
+import { ChannelType, Client, GatewayIntentBits } from "discord.js";
 import { ConvexHttpClient } from "convex/browser";
 import {
   serializeAuthor,
@@ -36,38 +31,6 @@ bot.on("ready", () => {
   console.log(
     `Bot is in ${bot.guilds.cache.size} guilds: ${bot.guilds.cache.map((guild) => guild.name).join(", ")}`,
   );
-});
-
-bot.on("threadCreate", async (thread) => {
-  // Check if the thread is in the "support-community" channel.
-  if (thread.parent?.name !== "support-community") {
-    return;
-  }
-
-  try {
-    const embed = new EmbedBuilder().setColor("#d7b3cf").setDescription(
-      `**Thanks for posting in <#1088161997662724167>.**
-Just a reminder: If you have a [Convex Pro account](https://www.convex.dev/pricing), please create a support ticket through your [Convex Dashboard](https://dashboard.convex.dev/) for any support requests.
-
-You can search for answers using [search.convex.dev](https://search.convex.dev), which covers docs, Stack, and Discord. Additionally, you can <@1072591948499664996> in the ⁠Convex Community <#1228095053885476985> channel.
-
-**Posting guidelines:**
-1. Provide context: What are you trying to achieve, what is the end-user interaction?
-1. Include full details of what you're seeing (full error message, command output, etc.)
-1. Describe what you'd like to see instead.
-
-Please note that community support is available here, and avoid tagging staff unless specifically instructed. Thank you!`,
-    );
-
-    await thread.send({
-      embeds: [embed],
-    });
-  } catch (error) {
-    console.error(
-      `Failed to send auto-reply to #support-community thread: ${thread.name}`,
-      error,
-    );
-  }
 });
 
 bot.on("messageCreate", async (msg) => {


### PR DESCRIPTION
Updates the Discord bot to auto-reply to new threads in the `#support-community` channel.

![image](https://github.com/user-attachments/assets/a647c898-fcd6-41e9-9bb6-28a05336a334)

Note that the screenshot is of the code running for a different Discord bot (convex-bot-dev), so the name and icon will be different when this is running on our production bot. And links like "Convex Community > ask-ai" should simply be "ask-ai".