### PR TITLE
Include guild ID in URL

### DIFF
--- a/packages/db/convex/indexing.ts
+++ b/packages/db/convex/indexing.ts
@@ -83,7 +83,7 @@ const hydrateSearchDocument = async ({
     title: thread.name,
     objectID: thread.id,
     channel: chan.name,
-    url: `https://discord.com/channels/${thread.guildId}/${channel.id}/${thread.id}`,
+    url: `https://discord.com/channels/${thread.guildId}/${thread.id}`,
     tags,
     messages: finalMessages,
     date: thread.createdTimestamp,

--- a/packages/db/convex/indexing.ts
+++ b/packages/db/convex/indexing.ts
@@ -83,7 +83,7 @@ const hydrateSearchDocument = async ({
     title: thread.name,
     objectID: thread.id,
     channel: chan.name,
-    url: `https://discord.com/channels/${channel.id}/${thread.id}`,
+    url: `https://discord.com/channels/${thread.guildId}/${channel.id}/${thread.id}`,
     tags,
     messages: finalMessages,
     date: thread.createdTimestamp,


### PR DESCRIPTION
We were previously generating Discord URLs in the format:
`https://discord.com/channels/{channel}/{thread}`

But it turns out that Discord expects:
`https://discord.com/channels/{guild}/{thread}`

Confirmed this by choosing the 'copy link' option in Discord. And verified the guildId and threadId in the Convex DB.